### PR TITLE
Add more homebrew binaries to PATH for macOS

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -83,6 +83,8 @@ PATH=$PATH:~/.bin/ovh
 # macOS specific path
 if [[ $OSTYPE == 'darwin'* ]]; then
   PATH=~/.homebrew/bin:$PATH # Homebrew binaries before default macOS binaries
+  PATH=~/.homebrew/sbin:$PATH # Homebrew superuser binaries before default macOS binaries
+  PATH=~/.homebrew/opt/ruby/bin:$PATH # Use Homebrew Ruby binaries
   PATH=$PATH:/usr/local/bin # local binaries
   PATH=$PATH:${HOME}/Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin
   # Go path


### PR DESCRIPTION
- Homebrew superuser binaries before default macOS binaries
- Use Homebrew Ruby binaries